### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/iac-deploy.yml
+++ b/.github/workflows/iac-deploy.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: aws-iac-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/disaenz/aws-iac/security/code-scanning/1](https://github.com/disaenz/aws-iac/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily interacts with AWS resources and does not appear to require write access to the repository, we will set the `contents` permission to `read`. This ensures that the `GITHUB_TOKEN` has only the minimal permissions required for the workflow to function.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs. This avoids redundancy and ensures consistency across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
