### PR TITLE
Switching to Private ECR Repo instead

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -1,18 +1,7 @@
-resource "aws_ecrpublic_repository" "services" {
-  provider        = aws.east1
-  repository_name = var.ecr_api_repository_name
-
-  catalog_data {
-    description = "Container images for portfolio services"
+resource "aws_ecr_repository" "grant_api" {
+  name = "grant-api"
+  image_scanning_configuration {
+    scan_on_push = true
   }
-
-  tags = {
-    Environment = "production"
-    Project     = "portfolio"
-  }
-}
-
-output "ecr_public_repository_url" {
-  description = "Public ECR repository URI"
-  value       = aws_ecrpublic_repository.services.repository_uri
+  force_delete = true
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,12 +1,15 @@
+data "aws_ecr_repository" "grant_api" {
+  name = aws_ecr_repository.grant_api.name
+}
+
 resource "aws_lambda_function" "grant_api" {
   function_name = "grant-api"
   package_type  = "Image"
-  image_uri     = var.grant_api_image_uri
+  image_uri     = "${data.aws_ecr_repository.grant_api.repository_url}:latest"
   role          = aws_iam_role.lambda_exec.arn
 
-  # if app is too slow, you can increase memory here
-  memory_size = 128
-  timeout     = 10
+  memory_size   = 128
+  timeout       = 10
 
   environment {
     variables = {


### PR DESCRIPTION
We need now to use a private repo instead. Lambda does NOT support Public ECR Images